### PR TITLE
Update README Travis Badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,8 +9,8 @@ Introduction
     :target: https://discord.gg/nBQh6qu
     :alt: Discord
 
-.. image:: https://travis-ci.org/adafruit/Adafruit__CircuitPython_CPython.svg?branch=master
-    :target: https://travis-ci.org/adafruit/Adafruit__CircuitPython_CPython
+.. image:: https://travis-ci.com/adafruit/Adafruit__CircuitPython_CPython.svg?branch=master
+    :target: https://travis-ci.com/adafruit/Adafruit__CircuitPython_CPython
     :alt: Build Status
 
 .. todo:: Describe what the library does.


### PR DESCRIPTION
Change 'travis-ci.org' to 'travis-ci.com'.