### PR TITLE
Correct pyproject metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ classifiers = [
 dynamic = ["dependencies", "optional-dependencies"]
 
 [tool.setuptools]
-py-modules = ["adafruit_colorsys"]
+py-modules = ["colorsys"]
 
 [tool.setuptools.dynamic]
 dependencies = {file = ["requirements.txt"]}


### PR DESCRIPTION
the file is named "colorsys.py", so this needs to match.

This discrepancy blocks some improvements I want to make to the bundle builder, to depend on this metadata.